### PR TITLE
feat #76: deliveryRoute update 임시 구현

### DIFF
--- a/com.msa_delivery.delivery/src/main/java/com/msa_delivery/delivery/application/service/DeliveryRouteService.java
+++ b/com.msa_delivery.delivery/src/main/java/com/msa_delivery/delivery/application/service/DeliveryRouteService.java
@@ -1,9 +1,12 @@
 package com.msa_delivery.delivery.application.service;
 
+import com.msa_delivery.delivery.application.dto.DeliveryRouteDto;
+import com.msa_delivery.delivery.domain.model.DeliveryManager;
 import com.msa_delivery.delivery.domain.model.DeliveryRoute;
 import com.msa_delivery.delivery.domain.model.DeliveryStatus;
+import com.msa_delivery.delivery.domain.repository.DeliveryManagerRepository;
 import com.msa_delivery.delivery.domain.repository.DeliveryRouteRepository;
-import com.msa_delivery.delivery.presentation.request.DeliveryUpdateRequest;
+import com.msa_delivery.delivery.presentation.request.DeliveryRouteRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,7 +18,75 @@ import java.util.UUID;
 public class DeliveryRouteService {
 
     private final DeliveryRouteRepository deliveryRouteRepository;
+    private final DeliveryManagerRepository deliveryManagerRepository;
+    private final DeliveryManagerService deliveryManagerService;
 
+    @Transactional
+    public DeliveryRouteDto updateRoute(UUID deliveryRouteId, DeliveryRouteRequest request, String userId, String username, String role) {
+        // TODO: 권한 검증
+        // 기존 데이터 조회
+        DeliveryRoute route = deliveryRouteRepository.findByIdAndIsDeleteFalse(deliveryRouteId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 배송 경로를 찾을 수 없습니다."));
+
+        // 실제 이동 거리 및 소요 시간
+        Integer distance = route.getDistance();
+        Integer duration = route.getDuration();
+
+        // 자동 계산된 값이 없을 경우에만 직접 업데이트 허용
+        if ((request.getDistance() != null || request.getDuration() != null)) {
+            if (distance != null || duration != null) {
+                throw new IllegalArgumentException("자동 계산된 값이 이미 존재합니다.");
+            }
+            distance = request.getDistance() != null ? request.getDistance() : distance;
+            duration = request.getDuration() != null ? request.getDuration() : duration;
+        }
+
+        // 배송 상태 업데이트
+        DeliveryStatus deliveryStatus = request.getDeliveryStatus() != null ?
+                DeliveryStatus.fromString(request.getDeliveryStatus()) : route.getDeliveryStatus();
+        if (request.getDeliveryStatus() != null) {
+            if (!route.getDeliveryStatus().nextStatus(deliveryStatus)) {
+                throw new IllegalArgumentException("잘못된 상태 전환입니다.");
+            }
+            // 배송 상태가 'IN_HUB_TRANSFER'이면 거리와 소요 시간 업데이트 불가
+            if (deliveryStatus == DeliveryStatus.IN_HUB_TRANSFER &&
+                    (request.getDistance() != null || request.getDuration() != null)) {
+                throw new IllegalArgumentException("배송 상태가 이동 중일 때는 거리와 소요 시간을 업데이트할 수 없습니다.");
+            }
+            // 배송 상태가 목적지 허브 도착일 경우 거리 및 소요 시간 계산
+            if (deliveryStatus == DeliveryStatus.ARRIVED_AT_DESTINATION_HUB) {
+                if (route.getStartTime() == null) {
+                    throw new IllegalArgumentException("배송 시작 시간이 기록되지 않았습니다.");
+                }
+                if (request.getDuration() == null && duration == null) {
+                    route.updateStatus(deliveryStatus); // 자동 계산
+                }
+            }
+        }
+
+        // 배송 담당자 업데이트
+        DeliveryManager currentManager = route.getDeliveryManager();
+        if (currentManager != null) {
+            // 기존 담당자의 orderId 초기화
+            deliveryManagerService.updateOrderId(currentManager, null);
+        }
+        // 새로운 배송 담당자 조회
+        // 배송 담당자는 한 번에 하나의 배송(주문) 만 처리
+        DeliveryManager newManager = deliveryManagerRepository.findById(request.getDeliveryManagerId())
+                .orElseThrow(() -> new IllegalArgumentException("지정된 새로운 배송 담당자를 찾을 수 없습니다."));
+        if (newManager.getOrderId() != null) {
+            throw new IllegalArgumentException("이미 배송이 지정되어 있는 담당자입니다.");
+        }
+        // 새로운 담당자에게 orderId 배정
+        deliveryManagerService.updateOrderId(newManager, route.getDelivery().getOrderId());
+
+        route.updateStatus(deliveryStatus);
+        route.update(newManager, distance, duration);
+        route.setUpdatedBy(username);
+        return DeliveryRouteDto.create(route);
+    }
+
+    // 배송 경로의 배송 상태 업데이트
     @Transactional
     public void updateRouteStatus(UUID deliveryId, DeliveryStatus deliveryStatus) {
         DeliveryRoute route = deliveryRouteRepository.findByDeliveryIdAndIsDeleteFalse(deliveryId)

--- a/com.msa_delivery.delivery/src/main/java/com/msa_delivery/delivery/domain/model/DeliveryRoute.java
+++ b/com.msa_delivery.delivery/src/main/java/com/msa_delivery/delivery/domain/model/DeliveryRoute.java
@@ -3,6 +3,7 @@ package com.msa_delivery.delivery.domain.model;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -33,7 +34,10 @@ public class DeliveryRoute extends BaseEntity{
     private Integer expectDistance;
     private Integer expectDuration;
     private Integer distance;
-    private Integer duration;
+    private Integer duration;   // (분)
+
+    private LocalDateTime startTime; // 이동 시작 시간
+    private LocalDateTime endTime;   // 이동 완료 시간
 
     @Enumerated(EnumType.STRING)
     private DeliveryStatus deliveryStatus;
@@ -54,6 +58,22 @@ public class DeliveryRoute extends BaseEntity{
     }
 
     public void updateStatus(DeliveryStatus deliveryStatus) {
+        // 상태 변경
+        if (deliveryStatus == DeliveryStatus.IN_HUB_TRANSFER) {
+            this.startTime = LocalDateTime.now();
+        } else if (deliveryStatus == DeliveryStatus.ARRIVED_AT_DESTINATION_HUB) {
+            this.endTime = LocalDateTime.now();
+            if (this.startTime != null) {
+                this.duration = (int) java.time.Duration.between(this.startTime, this.endTime).toMinutes();
+                this.distance = expectDistance;     // 일단 허브 도착하면 예상 값으로 업데이트 하도록
+            }
+        }
         this.deliveryStatus = deliveryStatus;
+    }
+
+    public void update(DeliveryManager newManager, Integer distance, Integer duration) {
+        this.deliveryManager = newManager;
+        this.distance = distance;
+        this.duration = duration;
     }
 }

--- a/com.msa_delivery.delivery/src/main/java/com/msa_delivery/delivery/domain/repository/DeliveryRouteRepository.java
+++ b/com.msa_delivery.delivery/src/main/java/com/msa_delivery/delivery/domain/repository/DeliveryRouteRepository.java
@@ -8,5 +8,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface DeliveryRouteRepository extends JpaRepository<DeliveryRoute, UUID>, JpaDeliveryRouteRepository {
+    Optional<DeliveryRoute> findByIdAndIsDeleteFalse(UUID deliveryRouteId);
+
     Optional<DeliveryRoute> findByDeliveryIdAndIsDeleteFalse(UUID deliveryId);
 }

--- a/com.msa_delivery.delivery/src/main/java/com/msa_delivery/delivery/presentation/controller/DeliveryManagerController.java
+++ b/com.msa_delivery.delivery/src/main/java/com/msa_delivery/delivery/presentation/controller/DeliveryManagerController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/delivery-routes")
+@RequestMapping("/api/delivery-managers")
 @RequiredArgsConstructor
 public class DeliveryManagerController {
 

--- a/com.msa_delivery.delivery/src/main/java/com/msa_delivery/delivery/presentation/controller/DeliveryRouteController.java
+++ b/com.msa_delivery.delivery/src/main/java/com/msa_delivery/delivery/presentation/controller/DeliveryRouteController.java
@@ -1,14 +1,47 @@
 package com.msa_delivery.delivery.presentation.controller;
 
+import com.msa_delivery.delivery.application.dto.CommonResponse;
+import com.msa_delivery.delivery.application.dto.DeliveryCreateDto;
+import com.msa_delivery.delivery.application.dto.DeliveryDto;
+import com.msa_delivery.delivery.application.dto.DeliveryRouteDto;
 import com.msa_delivery.delivery.application.service.DeliveryRouteService;
+import com.msa_delivery.delivery.presentation.request.DeliveryRequest;
+import com.msa_delivery.delivery.presentation.request.DeliveryRouteRequest;
+import com.msa_delivery.delivery.presentation.request.DeliveryUpdateRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/delivery-managers")
+@RequestMapping("/api/delivery-routes")
 @RequiredArgsConstructor
 public class DeliveryRouteController {
 
     private final DeliveryRouteService deliveryRouteService;
+
+    @PutMapping("/{deliveryRouteId}")
+    public ResponseEntity<?> updateDelivery(@PathVariable UUID deliveryRouteId,
+                                            @RequestBody DeliveryRouteRequest request,
+                                            @RequestHeader("X-User_Id") String userId,
+                                            @RequestHeader("X-Username") String username,
+                                            @RequestHeader("X-Role") String role) {
+        try {
+            DeliveryRouteDto route = deliveryRouteService.updateRoute(deliveryRouteId, request, userId, username, role);
+            return ResponseEntity.status(HttpStatus.CREATED).body(
+                    CommonResponse.success(HttpStatus.CREATED, "배송 정보 수정이 완료되었습니다.", route)
+            );
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(
+                    CommonResponse.error(HttpStatus.FORBIDDEN, e.getMessage())
+            );
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, "배송 정보 수정 중 오류가 발생했습니다.")
+            );
+        }
+    }
 }

--- a/com.msa_delivery.delivery/src/main/java/com/msa_delivery/delivery/presentation/request/DeliveryRouteRequest.java
+++ b/com.msa_delivery.delivery/src/main/java/com/msa_delivery/delivery/presentation/request/DeliveryRouteRequest.java
@@ -1,4 +1,16 @@
 package com.msa_delivery.delivery.presentation.request;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
 public class DeliveryRouteRequest {
+    // 배송이 생성되면, 출도착 허브, 예상 거리, 예상 소요시간 변경 불가
+    // 배송 경로 상태는 배송에서 관리
+    private Long deliveryManagerId;
+    private Integer distance;
+    private Integer duration;
+    private String deliveryStatus;
+
 }


### PR DESCRIPTION
## 개요
deliveryRoute update 임시 구현

## 상세 내용
1. 배송 경로 수정 조건 설정 - 배송 담당자, 배송 상태, 실제 소요시간, 실제 이동 거리만 직접 수정 가능
2. 배송 경로의 배송 상태의 경우 배송의 배송 상태가 변경되면 같이 변경되게 함
3. 실제 소요 시간 계산을 위해 배송 경로 테이블에 start_time, end_time 추가
4. 배송 상태가 허브 이동중으로 변경되면 start_time 기록, 목적지 허브로 변경되면 end_time 기록 후 실제 소요 시간 계산

Issue ID : #76 

## 유형

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [x]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [x]  파일 혹은 폴더명 수정
- [x]  파일 혹은 폴더 삭제
- [x]  디자인

## Checklist
- [ ] 커밋 메세지를 컨벤션에 맞게 작성하셨나요?
- [ ] 작업 범위에 대해서 테스트를 작성하셨나요?
- [ ] 무엇을 변경했는지 충분히 설명하고 있나요?
