### PR TITLE
[refactor] #126: auth 서버 MASTER 권한 회원가입 시 master-key가 필요하도록 간단하게 구현.

### DIFF
--- a/com.msa_delivery.auth/src/main/java/com/msa_delivery/auth/application/dtos/AuthRequestDto.java
+++ b/com.msa_delivery.auth/src/main/java/com/msa_delivery/auth/application/dtos/AuthRequestDto.java
@@ -28,4 +28,7 @@ public class AuthRequestDto {
 
     @JsonProperty("slack_id")
     private String slackId;
+
+    @JsonProperty("master_key")
+    private String masterKey;
 }

--- a/com.msa_delivery.auth/src/main/java/com/msa_delivery/auth/application/service/AuthService.java
+++ b/com.msa_delivery.auth/src/main/java/com/msa_delivery/auth/application/service/AuthService.java
@@ -4,6 +4,7 @@ import com.msa_delivery.auth.application.dtos.ApiResponseDto;
 import com.msa_delivery.auth.application.dtos.AuthRequestDto;
 import com.msa_delivery.auth.application.dtos.AuthResponseDto;
 import com.msa_delivery.auth.domain.entity.User;
+import com.msa_delivery.auth.domain.entity.UserRoleEnum;
 import com.msa_delivery.auth.domain.repository.UserRepository;
 import com.msa_delivery.auth.infrastructure.dtos.VerifyUserDto;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
@@ -43,6 +44,9 @@ public class AuthService {
     @Value("${service.jwt.access-expiration}")
     private Long accessExpiration;
 
+    @Value("${security.master-key}")
+    private String masterKey;
+
     private static final String KEY_ALGORITHM = "HmacSHA256";
     private static final String BEARER_PREFIX = "Bearer ";
 
@@ -51,12 +55,21 @@ public class AuthService {
         return new SecretKeySpec(keyBytes, KEY_ALGORITHM);
     }
 
+    // TODO : MASTER 권한의 경우 추가 키가 필요하도록 설정. (실제론 관리자가 허락해줄때까지 대기하거나 추가 정보 등이 필요하다거나, DB에 key값을 hash로 저장하여 특정 시간에 업데이트 되는 값을 사용하도록 해야할듯.)
     @CircuitBreaker(name = "signUpCircuitBreaker", fallbackMethod = "fallbackSignUp")
     @Retry(name = "defaultRetry")
     public ResponseEntity<ApiResponseDto<AuthResponseDto>> signUp(AuthRequestDto userRequestDto) {
         if (userRepository.existsByUsername(userRequestDto.getUsername())) {
             throw new IllegalArgumentException("Username already exists");
         }
+
+        if (userRequestDto.getRole() == UserRoleEnum.MASTER) {
+            String masterKey = userRequestDto.getMasterKey();
+            if (masterKey == null || !masterKey.equals(getMasterKeyHash())) {
+                throw new IllegalArgumentException(masterKey == null ? "Master key required" : "Invalid master key");
+            }
+        }
+
         String password = userRequestDto.getPassword();
         String encodedPassword = passwordEncoder.encode(password);
 
@@ -153,5 +166,9 @@ public class AuthService {
                 .onFailureRateExceeded(event -> log.info("###CircuitBreaker Failure Rate Exceeded: {}", event)) // 실패율 초과 이벤트 리스너
                 .onCallNotPermitted(event -> log.info("###CircuitBreaker Call Not Permitted: {}", event)) // 호출 차단 이벤트 리스너
                 .onError(event -> log.info("###CircuitBreaker Error: {}", event)); // 오류 발생 이벤트 리스너
+    }
+
+    private String getMasterKeyHash() {
+        return masterKey;
     }
 }


### PR DESCRIPTION
- #126
- auth 서버 MASTER 권한 회원가입 시 master-key가 필요하도록 간단하게 구현.

## 개요
auth 서버 MASTER 권한 회원가입 시 master-key가 필요하도록 간단하게 구현.

## 상세 내용
- auth 서버 MASTER 권한 회원가입 시 master-key가 필요하도록 간단하게 구현.

Issue ID : #126 

## 유형

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [x]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [x]  파일 혹은 폴더명 수정
- [x]  파일 혹은 폴더 삭제
- [x]  디자인

## Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 작성하셨나요?
- [ ] 작업 범위에 대해서 테스트를 작성하셨나요?
- [x] 무엇을 변경했는지 충분히 설명하고 있나요?
