### PR TITLE
[feature] #128: MASTER 권한으로 유저 softDelete 시 delivery manager에 삭제 요청 완…

### DIFF
--- a/com.msa_delivery.user/src/main/java/com/msa_delivery/user/application/service/DeliveryService.java
+++ b/com.msa_delivery.user/src/main/java/com/msa_delivery/user/application/service/DeliveryService.java
@@ -9,9 +9,9 @@ import java.util.UUID;
 public interface DeliveryService {
     ResponseEntity<ApiResponseDto<GetUUIDDto>> getDeliveryByUserId(Long userId, String headerUserId, String username, String role);
 
-    ResponseEntity<ApiResponseDto<?>> softDeleteDelivery(UUID deliveryId);
+    ResponseEntity<ApiResponseDto<?>> softDeleteDelivery(UUID deliveryId, String headerUserId, String username, String role);
 
     ResponseEntity<ApiResponseDto<GetUUIDDto>> getDeliveryManagerByUserId(Long userId, String headerUserId, String username, String role);
 
-    ResponseEntity<ApiResponseDto<?>> softDeleteDeliveryManager(Long deliveryId);
+    ResponseEntity<ApiResponseDto<?>> softDeleteDeliveryManager(Long deliveryId, String headerUserId, String username, String role);
 }

--- a/com.msa_delivery.user/src/main/java/com/msa_delivery/user/application/service/UserService.java
+++ b/com.msa_delivery.user/src/main/java/com/msa_delivery/user/application/service/UserService.java
@@ -123,9 +123,6 @@ public class UserService {
         ResponseEntity<ApiResponseDto<GetUUIDDto>> deliveryManagerByUserId = deliveryService.getDeliveryManagerByUserId(user.getUserId(), headerUserId, headerUsername, role);
         ApiResponseDto<GetUUIDDto> deliveryManagerBody = deliveryManagerByUserId.getBody();
 
-        log.info("$$$$$$$$deliveryByUserId.getBody().getData() : {}", deliveryManagerBody.getData());
-        log.info("$$$$$$$$message : {}", deliveryManagerBody.getMessage());
-
         if (Objects.requireNonNull(deliveryManagerBody).getStatus() == HttpStatus.OK.value() ||
                 (deliveryManagerBody.getData() != null &&
                         deliveryManagerBody.getData().getContent() != null &&
@@ -135,7 +132,7 @@ public class UserService {
 
             for (GetUUIDDto.UUIDListDto content : contentList) {
                 if (content != null && content.getDeliveryManagerId() != null) {
-                    deliveryService.softDeleteDeliveryManager(content.getDeliveryManagerId());
+                    deliveryService.softDeleteDeliveryManager(content.getDeliveryManagerId(), headerUserId, headerUsername, role);
                 }
             }
         }

--- a/com.msa_delivery.user/src/main/java/com/msa_delivery/user/infrastructure/client/DeliveryClient.java
+++ b/com.msa_delivery.user/src/main/java/com/msa_delivery/user/infrastructure/client/DeliveryClient.java
@@ -19,7 +19,10 @@ public interface DeliveryClient extends DeliveryService {
                                                                    @RequestHeader(value = "X-Role", required = true) @NotBlank String role);
 
     @DeleteMapping("/api/deliveries/{delivery_id}")
-    ResponseEntity<ApiResponseDto<?>> softDeleteDelivery(@PathVariable(name = "delivery_id") UUID deliveryId);
+    ResponseEntity<ApiResponseDto<?>> softDeleteDelivery(@PathVariable(name = "delivery_id") UUID deliveryId,
+                                                         @RequestHeader(value = "X-User_Id", required = true) @NotBlank String headerUserId,
+                                                         @RequestHeader(value = "X-Username", required = true) @NotBlank String username,
+                                                         @RequestHeader(value = "X-Role", required = true) @NotBlank String role);
 
     @GetMapping("/api/deliveries/delivery-managers")
     ResponseEntity<ApiResponseDto<GetUUIDDto>> getDeliveryManagerByUserId(@RequestParam(name = "delivery_manager_id") Long userId,
@@ -28,5 +31,9 @@ public interface DeliveryClient extends DeliveryService {
                                                                           @RequestHeader(value = "X-Role", required = true) @NotBlank String role);
 
     @DeleteMapping("/api/deliveries/delivery-managers/{delivery_manager_id}")
-    ResponseEntity<ApiResponseDto<?>> softDeleteDeliveryManager(@PathVariable(name = "delivery_manager_id") Long deliveryManagerId);
+    ResponseEntity<ApiResponseDto<?>> softDeleteDeliveryManager(@PathVariable(name = "delivery_manager_id") Long deliveryManagerId,
+                                                                @RequestHeader(value = "X-User_Id", required = true) @NotBlank String headerUserId,
+                                                                @RequestHeader(value = "X-Username", required = true) @NotBlank String username,
+                                                                @RequestHeader(value = "X-Role", required = true) @NotBlank String role
+    );
 }


### PR DESCRIPTION
- #128
- MASTER 권한으로 유저 softDelete 시 delivery manager에 삭제 요청 완료. 응답 데이터에 맞는 dto 추가 구현.
- 테스트 확인.

## 개요
MASTER 권한으로 유저 softDelete 시 delivery manager에 삭제 요청 완료. 응답 데이터에 맞는 dto 추가 구현.

## 상세 내용
- #128
- MASTER 권한으로 유저 softDelete 시 delivery manager에 삭제 요청 완료. 응답 데이터에 맞는 dto 추가 구현.
- 테스트 확인.

Issue ID : #128 

## 유형

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [x]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [x]  파일 혹은 폴더명 수정
- [x]  파일 혹은 폴더 삭제
- [x]  디자인

## Checklist
- [ ] 커밋 메세지를 컨벤션에 맞게 작성하셨나요?
- [ ] 작업 범위에 대해서 테스트를 작성하셨나요?
- [ ] 무엇을 변경했는지 충분히 설명하고 있나요?
